### PR TITLE
Load external scripts without blocking rendering

### DIFF
--- a/src/htmlFormatter.kk
+++ b/src/htmlFormatter.kk
@@ -364,7 +364,7 @@ public function fmtHtmlFull(html : string, options : options, metadata : dict<st
               log("filesRefer",link);
               log("embed",link);
             }
-            "  <script src=\"" + escape(link) + "\" " + attrs.htmlFormat("script",False) + "></script>\n" 
+            "  <script src=\"" + escape(link) + "\" " + attrs.htmlFormat("script",False) + " async></script>\n" 
           }
         }
       }).join 
@@ -386,7 +386,7 @@ public function fmtHtmlFull(html : string, options : options, metadata : dict<st
        "  });", 
        "</script>",
        "<script type=\"text/javascript\"",
-       "  src=\"" + options.getMathjax.expand.escape + "\">",
+       "  src=\"" + options.getMathjax.expand.escape + "\" async>",
        "</script>\n"
       ].join("\n  ")
    }) +


### PR DESCRIPTION
External scripts normally force the browser to wait for the JavaScript to be fetched, which may add one or more network roundtrips before the page can be rendered. 

So javaScript blocks DOM construction and thus delays the time to first render. To prevent JavaScript from blocking the parser we use the `async` attribute for external scripts.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/houshuang/madoko/2)

<!-- Reviewable:end -->
